### PR TITLE
Fix update endpoint to use path id

### DIFF
--- a/src/main/java/com/mvs/dynamodb/web/controller/ProductController.java
+++ b/src/main/java/com/mvs/dynamodb/web/controller/ProductController.java
@@ -52,7 +52,8 @@ public class ProductController {
 
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<Product> update(@Valid @RequestBody Product product) {
+    public ResponseEntity<Product> update(@PathVariable String id, @Valid @RequestBody Product product) {
+        product.setId(id);
         return ResponseEntity.status(HttpStatus.OK).body(productService.update(product));
     }
 


### PR DESCRIPTION
## Summary
- ensure `ProductController` uses the path variable when updating a product

## Testing
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685fd3409c50832590d889f90180c5e6