### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You can populate for put as well.
 To access REST API documentation you can use: http://localhost:8080/swagger-ui/
 1. To access product-api-v1 version 1.0 documentation by using http://localhost:8080/v2/api-docs?group=product-api-v1.0
 
-![swagger-ui-secreenshot](https://i.ibb.co/6Pm8H4q/Screenshot-2022-02-14-at-12-49-07.png)
+![swagger-ui-screenshot](https://i.ibb.co/6Pm8H4q/Screenshot-2022-02-14-at-12-49-07.png)
 
 ## Storage Destroy
 To destroy the storage, we need to run the following command:


### PR DESCRIPTION
## Summary
- fix screenshot typo

## Testing
- `./mvnw -q test` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685fd571d4608325914086aca03f84c5